### PR TITLE
Bundle image

### DIFF
--- a/UNUMCanvas/Classes/CanvasController.swift
+++ b/UNUMCanvas/Classes/CanvasController.swift
@@ -138,8 +138,6 @@ extension CanvasController {
     
     @objc private func tapOnViewController(_ sender: UITapGestureRecognizer) {
         
-        selectedViewObservingDelegate?.tapWasInSelectableView?()
-        
         // only act on completed clicks
         guard sender.state == .ended else {
             return
@@ -161,6 +159,9 @@ extension CanvasController {
                 guard viewClicked else {
                     continue
                 }
+                
+                // since tap was within an interactableView, indicate that the tap was within a selectableView.
+                selectedViewObservingDelegate?.tapWasInSelectableView?()
                 
                 // delete the view if the click was within the delete icon
                 let deletedView = deleteButtonPressed(on: view, sender: sender)

--- a/UNUMCanvas/Classes/SelectionShowingView.swift
+++ b/UNUMCanvas/Classes/SelectionShowingView.swift
@@ -20,9 +20,11 @@ final class SelectionShowingView: UIView {
     }
     
     init() {
-        var bundle = Bundle(identifier: "org.cocoapods.UNUMCanvas")
-        if let resourcePath = bundle?.path(forResource: "UNUMCanvas", ofType: "bundle") {
-            bundle = Bundle(path: resourcePath)!
+        var bundle = Bundle(for: SelectionShowingView.self)
+        if let resourcePath = bundle.path(forResource: "UNUMCanvas", ofType: "bundle") {
+            if let resourcesBundle = Bundle(path: resourcePath) {
+                bundle = resourcesBundle
+            }
         }
         let closeImage = UIImage(named: "deleteImageIcon", in: bundle, compatibleWith: nil)
         closeImageView = UIImageView(image: closeImage)


### PR DESCRIPTION
This does two main things.

1. It fixes the retrieval of the image assets within the pod.
2. It fixes tap-handling when the canvasController is in the same area as a collectionView or tableView -- essentially allowing someone implementing the canvasController the ability to determine how it should interact with the collection/table view's taps. Before it was indicating tap on every tap rather than specifying that a tap was in an interactive view.