### PR TITLE
Ios 45

### DIFF
--- a/Example/UNUMCanvas/ExampleCanvasCollectionViewController.swift
+++ b/Example/UNUMCanvas/ExampleCanvasCollectionViewController.swift
@@ -4,7 +4,7 @@ import Anchorage
 
 final class ExampleCanvasCollectionViewController: UIViewController {
     
-    private let canvasController = CanvasController()
+    private let canvasController = CanvasController(viewSelectionStyle: .image)
     private let canvasRegion = CanvasRegionView()
 
     private let collectionView: UICollectionView
@@ -112,9 +112,11 @@ final class ExampleCanvasCollectionViewController: UIViewController {
         canvasRegion.interactableViews.append(contentsOf: [interactableView1, interactableView2, interactableView3, interactableTextLabel])
         canvasRegion.regionView = view
         
-        canvasController.selectedView = interactableView3
         canvasController.gestureRecognizingView = collectionView
         canvasController.canvasRegionViews = [canvasRegion]
+
+
+        canvasController.selectedView = interactableView3
     }
 }
 

--- a/Example/UNUMCanvas/ExampleSingleCanvasViewController.swift
+++ b/Example/UNUMCanvas/ExampleSingleCanvasViewController.swift
@@ -4,7 +4,7 @@ import Anchorage
 
 final class ExampleSingleCanvasViewController: UIViewController {
     
-    private let canvasController = CanvasController()
+    private let canvasController = CanvasController(viewSelectionStyle: .image)
     private let canvasRegion = CanvasRegionView()
     
     private var interactableView1 = UIView()
@@ -44,8 +44,10 @@ final class ExampleSingleCanvasViewController: UIViewController {
         canvasRegion.canvasViews = [view]
         canvasRegion.regionView = view
         
-        canvasController.selectedView = interactableView1
         canvasController.gestureRecognizingView = view
         canvasController.canvasRegionViews = [canvasRegion]
+
+
+        canvasController.selectedView = interactableView1
     }
 }

--- a/Example/UNUMCanvas/MultipleCanvasRegionViewController.swift
+++ b/Example/UNUMCanvas/MultipleCanvasRegionViewController.swift
@@ -4,7 +4,7 @@ import Anchorage
 
 final class MultipleCanvasRegionViewController: UIViewController {
     
-    private let canvasController = CanvasController()
+    private let canvasController = CanvasController(viewSelectionStyle: .region)
     private let canvasRegion1 = CanvasRegionView()
     private let canvasRegion2 = CanvasRegionView()
     
@@ -35,9 +35,15 @@ final class MultipleCanvasRegionViewController: UIViewController {
         // first region
         region1View = UIView()
         view.addSubview(region1View)
-        region1View.topAnchor == view.topAnchor
+        if #available(iOS 11.0, *) {
+            region1View.topAnchor == view.safeAreaLayoutGuide.topAnchor
+            region1View.bottomAnchor == view.safeAreaLayoutGuide.bottomAnchor
+        } else {
+            region1View.topAnchor == view.topAnchor
+            region1View.bottomAnchor == view.bottomAnchor
+        }
         region1View.leadingAnchor == view.leadingAnchor
-        region1View.sizeAnchors == CGSize(width: halfWidth, height: view.frame.height)
+        region1View.widthAnchor == halfWidth
         
         region1View.backgroundColor = .lightGray
         region1View.clipsToBounds = true
@@ -47,9 +53,15 @@ final class MultipleCanvasRegionViewController: UIViewController {
         region2View = UIView()
         view.addSubview(region2View)
         
-        region2View.topAnchor == view.topAnchor
+        if #available(iOS 11.0, *) {
+            region2View.topAnchor == view.safeAreaLayoutGuide.topAnchor
+            region2View.bottomAnchor == view.safeAreaLayoutGuide.bottomAnchor
+        } else {
+            region2View.topAnchor == view.topAnchor
+            region2View.bottomAnchor == view.bottomAnchor
+        }
         region2View.leadingAnchor == view.leadingAnchor + halfwayLocation
-        region2View.sizeAnchors == CGSize(width: halfWidth, height: view.frame.height)
+        region2View.widthAnchor == halfWidth
         
         region2View.clipsToBounds = true
         region2View.backgroundColor = .darkGray
@@ -87,8 +99,10 @@ final class MultipleCanvasRegionViewController: UIViewController {
         
         
         // finish setup of canvasController
-        canvasController.selectedView = interactableView1
         canvasController.gestureRecognizingView = view
         canvasController.canvasRegionViews = [canvasRegion1, canvasRegion2]
+        
+        
+        canvasController.selectedView = interactableView1
     }
 }

--- a/UNUMCanvas/Classes/CanvasController+TapGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+TapGesture.swift
@@ -21,7 +21,9 @@ extension CanvasController {
                     assertionFailure("There shouldn't be a delete button if there is no view selected")
                     return
                 }
-                
+                if let superview = selectView.superview {
+                    selectedViewObservingDelegate?.selectedViewWasRemoved?(from: superview)
+                }
                 selectView.removeFromSuperview()
                 
                 canvasRegionViews.forEach({ canvasRegionView in

--- a/UNUMCanvas/Classes/CanvasController+TapGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+TapGesture.swift
@@ -11,20 +11,21 @@ import Foundation
 extension CanvasController {
     
     @objc func deleteButtonPressed(on view: UIView, sender: UITapGestureRecognizer) -> Bool {
-        guard view == selectedView else {
-            return false
-        }
-        
         var actionPerformed = false
         view.subviews.forEach { subview in
             if
                 let subview = subview as? SelectionShowingView,
                 subview.closeImageView.bounds.contains(sender.location(in: subview.closeImageView))
             {
-                view.removeFromSuperview()
+                guard let selectView = selectedView else {
+                    assertionFailure("There shouldn't be a delete button if there is no view selected")
+                    return
+                }
+                
+                selectView.removeFromSuperview()
                 
                 canvasRegionViews.forEach({ canvasRegionView in
-                    if let index = canvasRegionView.interactableViews.firstIndex(of: view) {
+                    if let index = canvasRegionView.interactableViews.firstIndex(of: selectView) {
                         canvasRegionView.interactableViews.remove(at: index)
                     }
                 })
@@ -51,69 +52,100 @@ extension CanvasController {
                 continue
             }
             
-            // 'Reversed' makes sure the view at the highest layer is selected rather than views farther down.
-            for view in canvasRegion.interactableViews.reversed() {
-                
-                // ensure the click was within the given interactableView
-                let viewClicked = view.point(inside: sender.location(in: view), with: nil)
-                guard viewClicked else {
-                    continue
-                }
-                
-                // since tap was within an interactableView, indicate that the tap was within a selectableView.
-                selectedViewObservingDelegate?.tapWasInSelectableView?()
-                
-                // delete the view if the click was within the delete icon
-                let deletedView = deleteButtonPressed(on: view, sender: sender)
-                
-                // don't continue after a successful delete
-                guard deletedView == false else {
+            switch viewSelectionStyle {
+            case .image:
+                if handleTapEventInImage(in: canvasRegion, sender: sender) {
                     return
                 }
-                
-                // If click was within selected view, then deselect and return.
-                if let unwrappedView = selectedView, unwrappedView == view {
-                    selectedView = nil
-                    return
-                }
-                    // Otherwise set the clicked view as the selected view and return.
-                else {
-                    selectedView = view
+            case .region:
+                if handleTapEventInRegion(in: canvasRegion, sender: sender) {
                     return
                 }
             }
         }
         
-        //        // If click is within movableViews, set to first one.
-        //        // 'Reversed' makes sure the view at the highest layer is selected rather than views farther down.
-        //        for view in allInteractableViews.reversed() {
-        //
-        //            let deletedView = deleteButtonPressed(on: view, sender: sender)
-        //
-        //            guard
-        //                sender.state == .ended,
-        //                deletedView == false
-        //                else {
-        //                    return
-        //            }
-        //
-        //            let viewClicked = view.point(inside: sender.location(in: view), with: nil)
-        //            guard viewClicked else {
-        //                continue
-        //            }
-        //            // If click was within selected view, then deselect and return.
-        //            if let unwrappedView = selectedView, unwrappedView == view {
-        //                selectedView = nil
-        //                return
-        //            }
-        //            // Otherwise set the clicked view as the selected view and return.
-        //            else {
-        //                selectedView = view
-        //                return
-        //            }
-        //        }
-        
         // If click was not within any movableView, then set to nil (making all views deselected).
         selectedView = nil
+    }
+    
+    /// Return true if the tap resulted in a view selection-event
+    /// Return false if the tap did not result in any view selection-event
+    func handleTapEventInImage(in canvasRegion: CanvasRegionView, sender: UITapGestureRecognizer) -> Bool {
+        // 'Reversed' makes sure the view at the highest layer is selected rather than views farther down.
+        for view in canvasRegion.interactableViews.reversed() {
+            
+            // ensure the click was within the given interactableView
+            let viewClicked = view.point(inside: sender.location(in: view), with: nil)
+            guard viewClicked else {
+                continue
+            }
+            
+            // since tap was within an interactableView, indicate that the tap was within a selectableView.
+            selectedViewObservingDelegate?.tapWasInSelectableView?()
+            
+            // delete the view if the click was within the delete icon
+            let deletedView = deleteButtonPressed(on: view, sender: sender)
+            
+            // don't continue after a successful delete
+            guard deletedView == false else {
+                return true
+            }
+            
+            // If click was within selected view, then deselect and return.
+            if let unwrappedView = selectedView, unwrappedView == view {
+                selectedView = nil
+                return true
+            }
+                // Otherwise set the clicked view as the selected view and return.
+            else {
+                selectedView = view
+                return true
+            }
+        }
+        return false
+    }
+    
+    /// Return true if the tap resulted in a view selection-event
+    /// Return false if the tap did not result in any view selection-event
+    func handleTapEventInRegion(in canvasRegion: CanvasRegionView, sender: UITapGestureRecognizer) -> Bool {
+        // this functionality does not support multiple interactable views in a canvasRegion for the time being.
+        guard canvasRegion.interactableViews.count < 2 else {
+            assertionFailure("We have not done the necessary work to be able to have multiple interactable views per region. For now it can be assumed that each region will only ever have one interactable view.")
+            return false
+        }
+        
+        // make sure region has a selectable view.
+        guard let selectableView = canvasRegion.interactableViews.first else {
+            return false
+        }
+        
+        // ensure the click was within the given canvasRegion
+        let viewClicked = canvasRegion.regionView.point(inside: sender.location(in: canvasRegion.regionView), with: nil)
+        guard viewClicked else {
+            return false
+        }
+        
+        // since tap was within a regionView, indicate that the tap was within a selectableView.
+        selectedViewObservingDelegate?.tapWasInSelectableView?()
+        
+        // delete the view if the click was within the delete icon
+        let deletedView = deleteButtonPressed(on: canvasRegion.regionView, sender: sender)
+        
+        // don't continue after a successful delete
+        guard deletedView == false else {
+            return true
+        }
+        
+        // If click was within selected canvasRegion, then deselect the selectedView and return.
+        for subview in canvasRegion.regionView.subviews {
+            if subview is SelectionShowingView {
+                selectedView = nil
+                return true
+            }
+        }
+        
+        // Otherwise set the clicked view as the selected view and return.
+        selectedView = selectableView
+        return true
     }
 }

--- a/UNUMCanvas/Classes/CanvasController.swift
+++ b/UNUMCanvas/Classes/CanvasController.swift
@@ -52,7 +52,7 @@ public class CanvasController: NSObject {
     /// The area interactable views are limited to and differentiates click-regions. If clicking in that region, then only interactableViews of that region should be considered interactable.
     public var canvasRegionViews: [CanvasRegionView] = []
     
-    private let viewSelectionStyle: ViewSelectionStyle
+    let viewSelectionStyle: ViewSelectionStyle
     
     public var selectedView: UIView? {
         didSet {

--- a/UNUMCanvas/Classes/CanvasController.swift
+++ b/UNUMCanvas/Classes/CanvasController.swift
@@ -34,6 +34,9 @@ class PanScalingType {
     
     /// An optional function indicating when a tap was in a selectableView. This is needed only when there are other entities that are handling tap events in the same clickable-area, such as if an interactableView is added on top of a tableView or a collectionView. This enables you to make sure to disable their tap events when the tap is within an interactableView.
     @objc optional func tapWasInSelectableView()
+    
+    /// An optional function that is called when the selectedView is removed from its superview. This function should be implemented if the removal is an event that needs to be handled. For example, if you need to add an "add" button to the canvasRegion when its interactableView is deleted, then you would do that using this function.
+    @objc optional func selectedViewWasRemoved(from superview: UIView)
 }
 
 public class CanvasRegionView {


### PR DESCRIPTION
For UNUMStory, design wanted the selection and delete button to be on the RegionView/CanvasPositionView rather than on the imageView itself. This is likely because of three issues with UNUMStories if the selection and delete button are on the image itself:
1. If the image is zoomed in too much, it's hard to tell it's selected when the border is greater than the RegionView.
2. Similarly you wouldn't be able to push the delete button.
3. It's nice to be able to see the full area of the region and putting the border on the region helps do this.

However, there is a tension with this notion and that of UNUMOffset -- which needs the border and close button to be on the image itself since there isn't a "region" they are added to.

So, UNUMCanvas has to be able to support both of these cases. This PR does that by creating a ViewSelectionStyle for the CanvasController.

If the ViewSelectionStyle is Image: then it acts as before.
If the ViewSelectionStyle is Region:
- taps in the region will select/deselect the InteractableView in the region
- delete button will delete the InteractableView in the region
- NOTE: For this to work, there can only be one view in the region view. This has been the case up until now; but if future work decides for us to add multiple images into the region (which the CanvasController was supporting even though there was never an implementation), then there will have to be some rework here around selection logic etc.

UNUMStory also needs a callback for when an InteractableView is deleted so that it knows it needs to add a new "add" button. This also has been added to CanvasController's SelectedViewObserving delegate as an optional function -- as it only needs to be implemented if something special needs to happen when an InteractableView is deleted.

Before:
<img width="432" alt="screen shot 2018-12-14 at 5 25 27 pm" src="https://user-images.githubusercontent.com/9424428/50037386-6997db00-ffc5-11e8-8e37-b9f30dbd1b53.png">
<img width="437" alt="screen shot 2018-12-14 at 5 25 34 pm" src="https://user-images.githubusercontent.com/9424428/50037387-6997db00-ffc5-11e8-81e1-3a1e2fd6fe27.png">

After:
<img width="433" alt="screen shot 2018-12-14 at 5 24 08 pm" src="https://user-images.githubusercontent.com/9424428/50037390-71577f80-ffc5-11e8-9cec-be175bc834ab.png">
<img width="428" alt="screen shot 2018-12-14 at 5 24 15 pm" src="https://user-images.githubusercontent.com/9424428/50037391-71577f80-ffc5-11e8-9d04-ef75284df6e2.png">
<img width="430" alt="screen shot 2018-12-14 at 5 24 30 pm" src="https://user-images.githubusercontent.com/9424428/50037392-71577f80-ffc5-11e8-9f1c-1aedde66b7bc.png">

