### PR TITLE
IOS-47 Add callback for when view is modified on canvas

### DIFF
--- a/Example/UNUMCanvas/ExampleCanvasCollectionViewController.swift
+++ b/Example/UNUMCanvas/ExampleCanvasCollectionViewController.swift
@@ -171,4 +171,8 @@ extension ExampleCanvasCollectionViewController: SelectedViewObserving {
     func tapWasInSelectableView() {
         skipTapEventOnce = true
     }
+    
+    func viewWasModified(view: UIView) {
+        print("view was modified")
+    }
 }

--- a/UNUMCanvas/Classes/CanvasController+PanGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+PanGesture.swift
@@ -11,12 +11,17 @@ import Foundation
 extension CanvasController {
     
     @objc func panOnViewController(_ sender: UIPanGestureRecognizer) {
-        if sender.state == .ended {
-            hideAllAxisIndicators()
+        guard let selectedView = selectedView else {
             return
         }
         
-        moveSelectedViewAndShowIndicatorViewsIfNecessary(sender)
+        if sender.state == .ended {
+            hideAllAxisIndicators()
+            indicateViewWasModified()
+            return
+        }
+        
+        moveSelectedViewAndShowIndicatorViewsIfNecessary(sender, selectedView: selectedView)
     }
     
     private func hideAllAxisIndicators() {
@@ -26,13 +31,10 @@ extension CanvasController {
         })
     }
     
-    func moveSelectedViewAndShowIndicatorViewsIfNecessary(_ sender: UIPanGestureRecognizer) {
+    private func moveSelectedViewAndShowIndicatorViewsIfNecessary(_ sender: UIPanGestureRecognizer, selectedView: UIView) {
         assert(allCanvasViews.count > 0)
-        guard
-            let selectedView = selectedView,
-            let selectedRegion = canvasRegionViews.filter({ $0.interactableViews.contains(selectedView) }).first
-            else {
-                return
+        guard let selectedRegion = canvasRegionViews.filter({ $0.interactableViews.contains(selectedView) }).first else {
+            return
         }
         
         let location = sender.location(in: selectedView)

--- a/UNUMCanvas/Classes/CanvasController+PinchGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+PinchGesture.swift
@@ -54,5 +54,9 @@ extension CanvasController {
         
         // reset scale after applying in order to keep scaling linear rather than exponential
         sender.scale = 1.0
+        
+        if sender.state == .ended {
+            indicateViewWasModified()
+        }
     }
 }

--- a/UNUMCanvas/Classes/CanvasController+RotateGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+RotateGesture.swift
@@ -14,6 +14,7 @@ extension CanvasController {
         guard let selectedView = selectedView else {
             return
         }
+        
         let t = CGAffineTransform(rotationAngle: sender.rotation).concatenating(selectedView.transform)
         
         let rotation = CGFloat(atan2(Double(t.b), Double(t.a)))
@@ -49,5 +50,9 @@ extension CanvasController {
         }
         
         sender.rotation = 0
+        
+        if sender.state == .ended {
+            indicateViewWasModified()
+        }
     }
 }

--- a/UNUMCanvas/Classes/CanvasController.swift
+++ b/UNUMCanvas/Classes/CanvasController.swift
@@ -30,6 +30,7 @@ class PanScalingType {
 }
 
 @objc public protocol SelectedViewObserving: AnyObject {
+    /// Indicates when there has been a change in which view is selected.
     func selectedValueChanged(to view: UIView?)
     
     /// An optional function indicating when a tap was in a selectableView. This is needed only when there are other entities that are handling tap events in the same clickable-area, such as if an interactableView is added on top of a tableView or a collectionView. This enables you to make sure to disable their tap events when the tap is within an interactableView.


### PR DESCRIPTION
The main purpose of this PR is to allow implementors of UNUMCanvas to know when a view has been modified generally -- as in whether it has been moved, rotated, or scaled but not specifically which.

I am debouncing/throttling these callbacks so that they seem to be a reasonable amount. In the code below, I am not having the code give an alert until only at the end of a touch event. This means that as a view is being rotated/moved/scaled, the library is not sending out many alerts, but only once the rotation/move/scale touch event is done.

Since all of these could happen with one touch event, an additional debounce/throttle is added such that only one alert is sent if all three occurred. The implementation of this (since we build to iOS 9.3) has a potential for a bug but I do not think that the bug is actually possible, only theoretical. A note and assertionFailure have been added accordingly.