### PR TITLE
disable edge-scaling

### DIFF
--- a/UNUMCanvas/Classes/CanvasController+PanGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+PanGesture.swift
@@ -45,12 +45,13 @@ extension CanvasController {
             setScalingType(relativeLocation: relativeLocation)
         }
         
-        if panScalingType.horizontal == .notActivated && panScalingType.vertical == .notActivated {
-            moveView(sender, selectedView: selectedView, selectedRegion: selectedRegion)
-            return
-        }
-        
-        scaleView(sender, selectedView: selectedView, selectedRegion: selectedRegion)
+        // will be reactivated with https://unumdesign.atlassian.net/browse/IOS-105
+//        if panScalingType.horizontal == .notActivated && panScalingType.vertical == .notActivated {
+        moveView(sender, selectedView: selectedView, selectedRegion: selectedRegion)
+//            return
+//        }
+//
+//        scaleView(sender, selectedView: selectedView, selectedRegion: selectedRegion)
     }
     
     private func setScalingType(relativeLocation: PaningRelativeLocation) {


### PR DESCRIPTION
Disable edge-scaling since it is not effective after a view has been rotated and it's not worth the effort yet to get it working in that case.