### PR TITLE
IOS 267 -  Don't have small pans de-select view

### DIFF
--- a/Example/Podfile.lock
+++ b/Example/Podfile.lock
@@ -1,6 +1,6 @@
 PODS:
   - Anchorage (4.3)
-  - UNUMCanvas (2.1.3):
+  - UNUMCanvas (2.1.7):
     - Anchorage (= 4.3.0)
 
 DEPENDENCIES:
@@ -17,7 +17,7 @@ EXTERNAL SOURCES:
 
 SPEC CHECKSUMS:
   Anchorage: 21a98675245188427f0bcea21404d42a824a766f
-  UNUMCanvas: f8c735e76ba415c4140d0a116524693883e7ccab
+  UNUMCanvas: b2f84e3c7fceb2d1ca78518aac8ae34254218f50
 
 PODFILE CHECKSUM: 1f8ab7093a7b85f96cfab8966b0d833dfb39b221
 

--- a/UNUMCanvas/Classes/CanvasController+PanGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+PanGesture.swift
@@ -14,6 +14,8 @@ extension CanvasController {
         guard let selectedView = selectedView else {
             return
         }
+
+        updateTapGestureEnabledStateBasedOnOpposite(of: sender)
         
         if sender.state == .ended {
             hideAllAxisIndicators()
@@ -22,6 +24,15 @@ extension CanvasController {
         }
         
         moveSelectedViewAndShowIndicatorViewsIfNecessary(sender, selectedView: selectedView)
+    }
+
+    private func updateTapGestureEnabledStateBasedOnOpposite(of sender: UIPanGestureRecognizer) {
+        if sender.state == .began {
+            tapGesture.isEnabled = false
+        }
+        else if sender.state == .ended {
+            tapGesture.isEnabled = true
+        }
     }
     
     private func hideAllAxisIndicators() {

--- a/UNUMCanvas/Classes/CanvasController.swift
+++ b/UNUMCanvas/Classes/CanvasController.swift
@@ -158,7 +158,7 @@ public class CanvasController: NSObject {
     let absoluteVelocityEnablingLocking: CGFloat = 100
     let absoluteDistanceEnablingLocking: CGFloat = 20
 
-    private var tapGesture = UITapGestureRecognizer()
+    var tapGesture = UITapGestureRecognizer()
     private var panGesture = UIPanGestureRecognizer()
     private var pinchGesture = UIPinchGestureRecognizer()
     private var rotationGesture = UIRotationGestureRecognizer()


### PR DESCRIPTION
### Jira Ticket
<Adjust the ticket below to match the ticket>
[IOS 267 -  Don't have small pans de-select view](https://unumdesign.atlassian.net/browse/IOS-267)

### Purpose
When doing a small pan gesture and releasing it, often the view gets selected. This indicates that the tapGesture is getting activated. Although it shouldn't be getting activated, that's an issue with Apple and a non-solvable problem. So the best thing to do is to disable the tapGesture while a panGesture is in progress, and reenable it when the panGesture ends.

### What this PR Accomplishes
Disable tapGestures while a panGesture is in progress and reenable once the panGesture is done.
