### PR TITLE
IOS-757 - Scaling isn't happening from center in UNUMCanvas

### DIFF
--- a/UNUMCanvas/Classes/CanvasController+PinchGesture.swift
+++ b/UNUMCanvas/Classes/CanvasController+PinchGesture.swift
@@ -32,6 +32,7 @@ extension CanvasController {
             heightConstraint.constant = heightConstraint.constant * sender.scale
             
             if
+                widthDifference != 0,
                 let selectedImageView = selectedView as? UIImageView,
                 let image = selectedImageView.image
             {


### PR DESCRIPTION
Very small change. Fixes cases where widthDifference is 0, which happens sometimes inside UNUMStory.

NOTE: Scaling at non-zero rotations won't scale from center, there is some math that needs to be done using trig that isn't clear to me